### PR TITLE
Move list conversion to init, change error return

### DIFF
--- a/mwords/mwords.go
+++ b/mwords/mwords.go
@@ -9,20 +9,25 @@ import (
 
 const assetName = "113809of.fic"
 
-// NewGenerator creates a new flippant.Generator with a provided word list
-func NewGenerator() (*flippant.Generator, error) {
+var words []string
+
+func init() {
 	rw, err := Asset(assetName)
 
 	if err != nil {
-		return nil, fmt.Errorf("unable to load asset: %s", assetName)
+		panic(fmt.Sprintf("unable to load asset: %s", assetName))
 	}
-
-	var words []string
 
 	scanner := bufio.NewScanner(bytes.NewReader(rw))
 	for scanner.Scan() {
 		words = append(words, scanner.Text())
 	}
+}
 
-	return flippant.NewGenerator(words), nil
+// NewGenerator creates a new flippant.Generator with a provided word list
+func NewGenerator() *flippant.Generator {
+	ww := make([]string, len(words))
+	copy(ww, words)
+
+	return flippant.NewGenerator(words)
 }

--- a/mwords/mwords_test.go
+++ b/mwords/mwords_test.go
@@ -5,19 +5,11 @@ import (
 )
 
 func TestNewGenerator(t *testing.T) {
-	_, err := NewGenerator()
-
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	}
+	NewGenerator()
 }
 
 func TestGeneratorParameters(t *testing.T) {
-	g, err := NewGenerator()
-
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	}
+	g := NewGenerator()
 
 	words := make([]string, 1000)
 


### PR DESCRIPTION
Previously we'd return an error if loading of the asset file failed for
any reason; this should be considered a panic however: a failure to
load the packed file indicates a packaging error, not an operational
error.